### PR TITLE
fix: correct pnpm cache setup in CI workflows

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,12 +12,15 @@ jobs:
       SANITY_STUDIO_DATASET: production
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          cache_dependency_path: pnpm-lock.yaml
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Run install
         run: pnpm install
       - name: Build production bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,15 @@ jobs:
       SANITY_STUDIO_DATASET: production
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
       - uses: pnpm/action-setup@v6
         with:
           cache: true
+          cache_dependency_path: pnpm-lock.yaml
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - name: Run install
         run: pnpm install
       - name: Build production bundle


### PR DESCRIPTION
## What

Fix step ordering and cache configuration in both `pullrequest.yml` and `release.yml`.

## Why

All Dependabot PRs opened after May 26 were failing the `preview` job in ~30 seconds — too fast for a real install+build. The cause: `pnpm/action-setup` was running *after* `actions/setup-node`, and `setup-node` had no pnpm cache configured. `pnpm/action-setup` with `cache: true` but no `cache_dependency_path` was failing to correctly set up caching for Dependabot PRs.

The working `vuelfden` workflow (same action versions, green CI) uses the correct pattern: pnpm setup first, then node setup with `cache: pnpm` and an explicit `cache-dependency-path`.

## Changes

Both workflow files:
- Move `pnpm/action-setup` before `actions/setup-node`
- Add `cache_dependency_path: pnpm-lock.yaml` to `pnpm/action-setup`
- Add `cache: pnpm` and `cache-dependency-path: pnpm-lock.yaml` to `actions/setup-node`